### PR TITLE
fixed browserSync

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,7 @@ gulp.task('js', function() {
         }))
         .pipe(concat('bundle.js'))
         // .pipe(uglify()) uncomment when rdy for production
-        .pipe(sourcemaps.write())
+        .pipe(sourcemaps.write('./'))
         .pipe(gulp.dest('./public'))
         .on('end', reload);
 });
@@ -47,7 +47,7 @@ gulp.task('sass', function() {
         .pipe(sourcemaps.init())
         .pipe(sass())
         .pipe(concat('bundle.css'))
-        .pipe(sourcemaps.write())
+        .pipe(sourcemaps.write('./'))
         .pipe(gulp.dest('./public'))
         .pipe(browserSync.stream({
             match: '**/*.css'

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,14 @@
+{
+    "restartable": "rs",
+    "colours": "true",
+    "execMap": {
+        "js": "node"
+    },
+    "ignoreRoot": "ignoreRoot",
+    "watch": ["./models", "./serverControllers", "./server.js"],
+    "verbose": "false",
+    "stdout": "true",
+    "env": {
+        "NODE_ENV": "development"
+    }
+}


### PR DESCRIPTION
This adds a nodemon.json fixed the slow BrowserSync refreshing problem. Now anything (folders or files) you want Nodemon to watch (restart when changed) must be added to the watch array in the nodemon.json.
